### PR TITLE
this project uses python10 specific features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ repository = "http://github.com/chassing/qontract-development-cli"
 homepage = "http://github.com/chassing/qontract-development-cli"
 
 [tool.poetry.dependencies]
-python = ">=3.9"
+python = ">=3.10"
 Jinja2 = "^3.1.2"
 GitPython = "^3.1.27"
 typer = "^0.6.1"


### PR DESCRIPTION
When using python3.9 I get this:

```
    ignore_paths: Optional[Sequence[str | Path]] = None,
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```